### PR TITLE
Added missing tab parameter to glOnTab hook

### DIFF
--- a/projects/ee-golden-layout/src/lib/golden-layout.component.ts
+++ b/projects/ee-golden-layout/src/lib/golden-layout.component.ts
@@ -223,8 +223,8 @@ export class GoldenLayoutComponent implements OnInit, OnDestroy, ComponentInitCa
     }
 
     if (implementsGlOnTab(component)) {
-      container.on('tab', () => {
-        component.glOnTab();
+      container.on('tab', (tab) => {
+        component.glOnTab(tab);
       });
     }
   }

--- a/projects/ee-golden-layout/src/lib/hooks.ts
+++ b/projects/ee-golden-layout/src/lib/hooks.ts
@@ -1,4 +1,5 @@
 import * as GoldenLayout from 'golden-layout';
+import {Tab} from 'golden-layout';
 
 /**
  * Hook invoked after a component's container or the document has been resized.
@@ -37,5 +38,5 @@ export interface GlOnTab {
   /**
    * Invoked when the 'tab' event fires on the component's parent GoldenLayout Container.
    */
-  glOnTab(): void;
+  glOnTab(tab: Tab): void;
 }


### PR DESCRIPTION
For [tab customization](https://golden-layout.com/tutorials/extending-tabs.html), the tab parameter in the glOnTab is required. In this PR, I am just passing it through from golden-layout to the hook.