### PR TITLE
Prevent cross-origin frame SecurityError when referer different domain.

### DIFF
--- a/projects/ee-golden-layout/src/lib/golden-layout.service.ts
+++ b/projects/ee-golden-layout/src/lib/golden-layout.service.ts
@@ -98,10 +98,14 @@ export class GoldenLayoutService {
   }
 
   public isChildWindow(): boolean {
-    return !!window.opener;
+    try {
+      return !!window.opener && !!window.opener.location.href;
+    } catch (e) {
+      return false;
+    }
   }
 
   public getRootWindow(): Window {
-    return window.opener || window;
+    return this.isChildWindow() ? window.opener : window;
   }
 }


### PR DESCRIPTION
The GoldenLayoutService uses the presence of window.opener to work out
if it's a child window. This breaks when an app is arrived at as a
redirect from a different domain.

This patch makes golden layout additional check that the opener window
is not cross-origin when working out if it's in a child window.