### PR TITLE
missing exports

### DIFF
--- a/projects/ngx-golden-layout/package.json
+++ b/projects/ngx-golden-layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-golden-layout",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "license": "BSD-3-Clause",
   "author": {
     "name": "Martin Koppehel",

--- a/projects/ngx-golden-layout/src/public-api.ts
+++ b/projects/ngx-golden-layout/src/public-api.ts
@@ -1,6 +1,7 @@
 export * from './lib/config';
+export * from './lib/component-registry.service';
 export * from './lib/golden-layout.component';
-export { PluginRegistryService } from './lib/plugin-registry.service';
+export * from './lib/plugin-registry.service';
 export * from './lib/root-window.service';
 export * from './lib/hooks';
 export * from './lib/module';


### PR DESCRIPTION
We're currently mirroring `GoldenLayoutModule` with our own so we can inject some styling and behaviors.  Probably not the best practice, but it works in a pinch.  These exports are needed to properly define the module (being that most everything is exported it seems like an oversight).