### PR TITLE
Custom headers

### DIFF
--- a/projects/ngx-golden-layout/src/lib/golden-layout.component.ts
+++ b/projects/ngx-golden-layout/src/lib/golden-layout.component.ts
@@ -22,7 +22,8 @@ import * as GoldenLayout from 'golden-layout';
 import { ComponentRegistryService } from './component-registry.service';
 import { FallbackComponent, FailedComponent } from './fallback';
 import { RootWindowService } from './root-window.service';
-import { Observable, Subscription } from 'rxjs';
+import { Observable, Subscription, BehaviorSubject, of } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
 import {
   implementsGlOnResize,
   implementsGlOnShow,
@@ -31,7 +32,8 @@ import {
   implementsGlOnClose,
   implementsGlOnPopin,
   implementsGlOnUnload,
-  implementsGlOnPopout
+  implementsGlOnPopout,
+  implementsGlHeaderItem,
 } from './type-guards';
 import { Deferred } from './deferred';
 import { WindowSynchronizerService } from './window-sync.service';
@@ -95,6 +97,30 @@ const dragProxy = function(x, y, dragListener, layoutManager, contentItem, origi
 }
 lm.__lm.controls.DragProxy = dragProxy;
 
+const origStack = lm.__lm.items.Stack;
+const stackProxy = function(lm, config, parent) {
+  origStack.call(this, lm, config, parent);
+  this.activeContentItem$ = new BehaviorSubject<any>(null);
+  const callback = (ci) => this.activeContentItem$.next(ci);
+  this.on('activeContentItemChanged', callback);
+  const origDestroy = this._$destroy;
+  this._$destroy = () => {
+    this.off('activeContentItemChanged', callback);
+    this.activeContentItem$.complete();
+    origDestroy.call(this);
+  };
+  return this;
+}
+lm.__lm.utils.extend(stackProxy, origStack);
+lm.__lm.items.Stack = stackProxy;
+
+const origPopout = lm.__lm.controls.BrowserPopout;
+const popout = function(config, dimensions, parent, index, lm) {
+  console.log('popout', 'config', config);
+  return new origPopout(config, dimensions, parent, index, lm);
+};
+lm.__lm.controls.BrowserPopout = popout;
+
 @Component({
   selector: 'golden-layout-root',
   styles: [`
@@ -130,7 +156,10 @@ export class GoldenLayoutComponent implements OnInit, OnDestroy {
 
   resumeStateChange = () => this.stateChangePaused = false;
   pauseStateChange = () => this.stateChangePaused = true;
-  pushTabActivated = (ci: GoldenLayout.ContentItem) => this.tabActivated.emit(ci);
+  pushTabActivated = (ci: GoldenLayout.ContentItem) => {
+    console.log('activeContentItemChanged', ci);
+    this.tabActivated.emit(ci);
+  }
 
   private isChildWindow: boolean;
 
@@ -306,7 +335,27 @@ export class GoldenLayoutComponent implements OnInit, OnDestroy {
       }
       return this.buildConstructor(type);
     };
-
+    this.goldenLayout.on('stackCreated', (stack) => {
+      // Wait until the content item is loaded and done
+      stack.activeContentItem$.pipe(switchMap((contentItem: any) => {
+        if (!contentItem) {
+          return of(null);
+        }
+        return contentItem.instance;
+      })).subscribe(j => {
+        // This is the currently visible content item, after it's loaded.
+        // Therefore, we can check whether (and what) to render as header component here.
+        console.log('instance', j);
+      }, err => {
+        // Currently visible content item, but we don't have an item or the loading failed, so no header.
+        // -> Destroy the currently rendered header.
+        console.log('Error loading instance:', err)
+      }, () => {
+        // Stack was closed.
+        // -> Destroy the currently rendered header.
+        console.log('Stack collapsed');
+      });
+    })
     // Initialize the layout.
     this.goldenLayout.init();
     this.goldenLayout.on('stateChanged', this.pushStateChange);
@@ -323,6 +372,7 @@ export class GoldenLayoutComponent implements OnInit, OnDestroy {
     // Can't use an ES6 lambda here, since it is not a constructor
     const self = this;
     return function (container: GoldenLayout.Container, componentState: any) {
+      const d = new Deferred<any>();
       self.ngZone.run(() => {
         // Wait until the component registry can provide a type for the component
         // TBD: Maybe add a timeout here?
@@ -359,8 +409,10 @@ export class GoldenLayoutComponent implements OnInit, OnDestroy {
           // Listen to containerDestroy and window beforeunload, preventing a double-destroy
           container.on('destroy', destroyFn);
           self.onUnloaded.promise.then(destroyFn);
+          d.resolve(componentRef.instance);
         });
       });
+      return d.promise;
     };
   }
 

--- a/projects/ngx-golden-layout/src/lib/golden-layout.component.ts
+++ b/projects/ngx-golden-layout/src/lib/golden-layout.component.ts
@@ -17,6 +17,9 @@ import {
   Input,
   Output,
   EventEmitter,
+  StaticProvider,
+  Type,
+  ComponentRef,
 } from '@angular/core';
 import * as GoldenLayout from 'golden-layout';
 import { ComponentRegistryService } from './component-registry.service';
@@ -101,12 +104,17 @@ const origStack = lm.__lm.items.Stack;
 const stackProxy = function(lm, config, parent) {
   origStack.call(this, lm, config, parent);
   this.activeContentItem$ = new BehaviorSubject<any>(null);
-  const callback = (ci) => this.activeContentItem$.next(ci);
+  const callback = (ci) => {
+    if (this.activeContentItem$) {
+      this.activeContentItem$.next(ci)
+    };
+  };
   this.on('activeContentItemChanged', callback);
   const origDestroy = this._$destroy;
   this._$destroy = () => {
     this.off('activeContentItemChanged', callback);
     this.activeContentItem$.complete();
+    this.activeContentItem$ = null;
     origDestroy.call(this);
   };
   return this;
@@ -346,25 +354,55 @@ export class GoldenLayoutComponent implements OnInit, OnDestroy {
       return this.buildConstructor(type);
     };
     this.goldenLayout.on('stackCreated', (stack) => {
+      debugger;
+      const customHeaderElement = document.createElement('li');
+      customHeaderElement.classList.add('custom-header');
+      customHeaderElement.style.display = 'none';
+      const ctr = stack.header.controlsContainer[0] as HTMLUListElement;
+      let element: ComponentRef<any> = null;
+
+      ctr.prepend(customHeaderElement);
+
+      const disposeControl = () => {
+        customHeaderElement.style.display = 'none';
+        if (element) {
+          customHeaderElement.childNodes.forEach(e => customHeaderElement.removeChild(e));
+          element.destroy();
+          element = null;
+        }
+      };
+      const bootstrapComponent = (ct: Type<any>, tokens: StaticProvider[], injector: Injector) => {
+        if (element) {
+          disposeControl();
+        }
+        console.log('bootstrap!', ct);
+        customHeaderElement.style.display = '';
+        const factory = this.componentFactoryResolver.resolveComponentFactory(ct);
+        const headerInjector = Injector.create(tokens, injector);
+        element = this.viewContainer.createComponent(factory, undefined, injector);
+        customHeaderElement.prepend(element.location.nativeElement);
+      };
+
       // Wait until the content item is loaded and done
       stack.activeContentItem$.pipe(switchMap((contentItem: any) => {
         if (!contentItem) {
           return of(null);
         }
         return contentItem.instance;
-      })).subscribe(j => {
+      })).subscribe((j: ComponentRef<any> | null) => {
         // This is the currently visible content item, after it's loaded.
         // Therefore, we can check whether (and what) to render as header component here.
         console.log('instance', j);
-      }, err => {
-        // Currently visible content item, but we don't have an item or the loading failed, so no header.
-        // -> Destroy the currently rendered header.
-        console.log('Error loading instance:', err)
-      }, () => {
-        // Stack was closed.
-        // -> Destroy the currently rendered header.
-        console.log('Stack collapsed');
-      });
+        if (!j || !implementsGlHeaderItem(j.instance)) {
+          disposeControl();
+        } else {
+          bootstrapComponent(
+            j.instance.headerComponent,
+            j.instance.additionalTokens || [],
+            j.injector
+          );
+        }
+      }, disposeControl, disposeControl);
     })
     // Initialize the layout.
     this.goldenLayout.init();
@@ -419,7 +457,7 @@ export class GoldenLayoutComponent implements OnInit, OnDestroy {
           // Listen to containerDestroy and window beforeunload, preventing a double-destroy
           container.on('destroy', destroyFn);
           self.onUnloaded.promise.then(destroyFn);
-          d.resolve(componentRef.instance);
+          d.resolve(componentRef);
         });
       });
       return d.promise;

--- a/projects/ngx-golden-layout/src/lib/golden-layout.component.ts
+++ b/projects/ngx-golden-layout/src/lib/golden-layout.component.ts
@@ -115,8 +115,18 @@ lm.__lm.utils.extend(stackProxy, origStack);
 lm.__lm.items.Stack = stackProxy;
 
 const origPopout = lm.__lm.controls.BrowserPopout;
-const popout = function(config, dimensions, parent, index, lm) {
-  console.log('popout', 'config', config);
+const popout = function(config: GoldenLayout.ItemConfig[], dimensions, parent, index, lm) {
+  if (config.length !== 1) {
+    console.warn('This should not happen, permitting', config);
+  } else {
+    if (config[0].type === 'component') {
+      config = [{
+        type: 'stack',
+        title: config[0].title, // Required for adjustToWindowMode to work. (Line 1282 in 1.5.9)
+        content: [config[0]],
+      }];
+    }
+  }
   return new origPopout(config, dimensions, parent, index, lm);
 };
 lm.__lm.controls.BrowserPopout = popout;

--- a/projects/ngx-golden-layout/src/lib/hooks.ts
+++ b/projects/ngx-golden-layout/src/lib/hooks.ts
@@ -1,4 +1,5 @@
 import { Tab } from 'golden-layout';
+import { Type, StaticProvider } from '@angular/core';
 
 /**
  * Hook invoked after a component's container or the document has been resized.
@@ -81,3 +82,7 @@ export interface GlOnUnload {
    glOnUnload(): void;
 }
 
+export interface GlHeaderItem {
+  headerComponent: Type<any>;
+  additionalTokens?: StaticProvider[];
+}

--- a/projects/ngx-golden-layout/src/lib/type-guards.ts
+++ b/projects/ngx-golden-layout/src/lib/type-guards.ts
@@ -1,4 +1,4 @@
-import { GlOnResize, GlOnShow, GlOnHide, GlOnTab, GlOnClose, GlOnPopin, GlOnUnload, GlOnPopout } from "./hooks";
+import { GlOnResize, GlOnShow, GlOnHide, GlOnTab, GlOnClose, GlOnPopin, GlOnUnload, GlOnPopout, GlHeaderItem } from "./hooks";
 
 /**
  * Type guard which determines if a component implements the GlOnResize interface.
@@ -43,4 +43,7 @@ export function implementsGlOnUnload(obj: any): obj is GlOnUnload {
 }
 export function implementsGlOnPopout(obj: any): obj is GlOnPopout {
   return typeof obj === 'object' && typeof obj.glOnPopout === 'function';
+}
+export function implementsGlHeaderItem(obj: any): obj is GlHeaderItem {
+  return typeof obj === 'object' && typeof obj.headerComponent === 'function';
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -83,7 +83,8 @@ export class TestService {
 }
 
 @Component({
-  template: `<div>Hello, Header</div>`,
+  template: `<div></div>`,
+  styles: [`:host { display: contents; } div { background-color: yellow; width: 100%; height: 100%; }`],
   selector: `app-header-test`,
 })
 export class HeaderTestComponent {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -21,6 +21,7 @@ import {
   GlOnUnload,
 } from 'ngx-golden-layout';
 import { BehaviorSubject } from 'rxjs';
+import { GlHeaderItem } from 'projects/ngx-golden-layout/src/lib/hooks';
 
 const CONFIG: GoldenLayout.Config = {
   content: [{
@@ -79,6 +80,14 @@ export class TestService {
     this.id = '_' + Math.random().toString(36).substr(2, 9);
     console.log(`Creating testService, id: ${this.id}`);
   }
+}
+
+@Component({
+  template: `<div>Hello, Header</div>`,
+  selector: `app-header-test`,
+})
+export class HeaderTestComponent {
+
 }
 
 @Component({
@@ -160,7 +169,7 @@ export class TestComponent implements GlOnPopout, GlOnClose, GlOnHide, GlOnShow,
   template: `<h1>Test2</h1>`,
   selector: `app-tested`,
 })
-export class TestedComponent implements OnInit, OnDestroy, GlOnClose {
+export class TestedComponent implements OnInit, OnDestroy, GlOnClose, GlHeaderItem {
   constructor() { }
 
   public ngOnInit(): void {
@@ -169,6 +178,8 @@ export class TestedComponent implements OnInit, OnDestroy, GlOnClose {
   public ngOnDestroy(): void {
     (window.opener || window).console.log(`ngondestroy`);
   }
+
+  public headerComponent = HeaderTestComponent;
 
   public glOnClose(): Promise<void> {
     console.log(`glOnClose`);
@@ -217,7 +228,11 @@ const COMPONENTS: ComponentType[] = [
     RootComponent,
     TestComponent,
     TestedComponent,
-    FailComponent
+    FailComponent,
+    HeaderTestComponent,
+  ],
+  entryComponents: [
+    HeaderTestComponent
   ],
   imports: [
     BrowserModule,


### PR DESCRIPTION
Add the possibility to render additional items in the header next to the close button.
Furthermore, this unifies the behavior for popped out windows and stack drags.

Whenever the user pops out/in a stack into another stack, they will be flattened. 
![Screenshot from 2019-09-19 08-44-53](https://user-images.githubusercontent.com/5557633/65222009-7f8b7c80-dabe-11e9-9751-fef677e838ae.png)
![Screenshot from 2019-09-19 08-44-48](https://user-images.githubusercontent.com/5557633/65222012-80241300-dabe-11e9-90c1-8b32987f40eb.png)
